### PR TITLE
downgrade htdemucs_ft to htdemucs. 4x faster for slightly less accuracy.

### DIFF
--- a/diarize.py
+++ b/diarize.py
@@ -41,7 +41,7 @@ source_seperation_start_time = time.time()
 if args.stemming:
     # Isolate vocals from the rest of the audio
     return_code = os.system(
-        f'python3 -m demucs.separate -n htdemucs_ft --two-stems=vocals "{args.audio}" -o "temp_outputs"'
+        f'python3 -m demucs.separate -n htdemucs --two-stems=vocals "{args.audio}" -o "temp_outputs"'
     )
 
     if return_code != 0:
@@ -51,7 +51,7 @@ if args.stemming:
         vocal_target = args.audio
     else:
         temp_file_path= os.path.splitext(os.path.basename(args.audio))[0]
-        vocal_target = f"temp_outputs/htdemucs_ft/{temp_file_path}/vocals.wav"
+        vocal_target = f"temp_outputs/htdemucs/{temp_file_path}/vocals.wav"
 else:
     vocal_target = args.audio
 source_seperation_end_time = end_time = time.time()


### PR DESCRIPTION
From the [demucs repo](https://github.com/facebookresearch/demucs) docs:
 
<img width="750" alt="Screen Shot 2023-05-12 at 7 22 25 PM" src="https://github.com/llj0824/speech-diarization-via-OpenAi-Whisper/assets/6228411/9c9c879c-56fb-4244-ac98-c0f291a44d4c">


It's 4 times slower but "might" be slightly better. Changing so we get 4x speed for possibly slightly worse quality.